### PR TITLE
Turn on warnings for TODO and FIXME comments

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,7 +34,8 @@ module.exports = {
     "no-multi-spaces": 0,
     "no-console": 2,
     "no-alert": 2,
-    "no-restricted-syntax": 0
+    "no-restricted-syntax": 0,
+    "no-warning-comments": 1
   },
   "plugins": [
     "import",


### PR DESCRIPTION
TODO and FIXME comments are dangerous and can be forgotten about. It is
better to keep things like that in project/task management software so
it is not forgotten about; however, that can sometimes be difficult
depending on the project management system used. As a simple default, we
can enable warnings for these so they are seen every time the project is
linted.